### PR TITLE
feat: stabilise sensor values with rolling average

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -5,6 +5,8 @@
     "wifi_password": "Netowrk password",
     "mqtt_broker_ip": "###.###.##.##"
   },
+  "rolling_window": 3,
+  "ema_alpha": 0.2,
   "irrigation_points": [
     {
       "name": "Location A",

--- a/config.template.json
+++ b/config.template.json
@@ -7,6 +7,7 @@
   },
   "rolling_window": 3,
   "ema_alpha": 0.2,
+  "publish_interval_minutes": 5,
   "irrigation_points": [
     {
       "name": "Location A",

--- a/src/config.py
+++ b/src/config.py
@@ -49,6 +49,12 @@ def _parse_ads_address(ads_address_str: str) -> int:
     return address
 
 
+def _get_publish_interval_ms(conf: dict) -> int:
+    """Extract and convert publish_interval_minutes to milliseconds."""
+    publish_interval_minutes: int = get_if_valid("publish_interval_minutes", conf, int)
+    return publish_interval_minutes * 60 * 1000
+
+
 class NetworkConfig:
     def __init__(self, conf: dict) -> None:
         self.wifi_ssid: str = get_if_valid("wifi_ssid", conf, str)
@@ -88,6 +94,9 @@ class Config:
         self.rolling_window: int = get_if_valid("rolling_window", conf, int)
         self.ema_alpha: float = get_if_valid("ema_alpha", conf, float)
 
+        # Publish interval in minutes, converted to ms
+        self.publish_interval_ms: int = _get_publish_interval_ms(conf)
+
         for irrigation_point_conf in irrigation_points_conf:
             irrigation_point = IrrigationPointConfig(irrigation_point_conf)
             # Copy global smoothing params to each point for convenience
@@ -107,6 +116,7 @@ class Config:
             f"  mqtt_broker_ip: {self.network.mqtt_broker_ip}",
             f"rolling_window:   {self.rolling_window}",
             f"ema_alpha:        {self.ema_alpha}",
+            f"publish_interval: {self.publish_interval_ms // 60000} min ({self.publish_interval_ms} ms)",
             "irrigation_points:",
         ]
         for ip in self.irrigation_points.values():

--- a/src/irrigation_point.py
+++ b/src/irrigation_point.py
@@ -18,8 +18,12 @@ class IrrigationPoint:
         self._valve = Valve(config, logger)
 
     def get_sensor_value(self) -> float:
-        """Read the current soil moisture sensor value (0.0-1.0)."""
-        return self._sensor.read_value()
+        """Get the current averaged soil moisture sensor value (0.0-1.0)."""
+        return self._sensor.get_value()
+
+    def measure_sensor(self) -> None:
+        """Measure the sensor and update the rolling average without returning the value."""
+        self._sensor.measure()
 
     def open_valve(self) -> None:
         """Open the irrigation valve for this point."""

--- a/src/irrigation_station.py
+++ b/src/irrigation_station.py
@@ -1,4 +1,4 @@
-from machine import I2C, Pin
+from machine import I2C, Pin, Timer
 from ads1x15 import ADS1115
 from config import Config
 from irrigation_point import IrrigationPoint
@@ -13,6 +13,8 @@ class IrrigationStation:
         self._config = config
         self._points: dict[str, IrrigationPoint] = {}
         self._logger = logger
+        self._measurement_timer = Timer(-1)
+        self._pending_measurement = False
         
         # Initialize I2C bus (shared for all ADS modules)
         self._i2c = I2C(0, scl=Pin(1), sda=Pin(0), freq=400000)
@@ -24,6 +26,9 @@ class IrrigationStation:
         for point_id, point_conf in self._config.irrigation_points.items():
             ads = self._ads_modules[point_conf.ads_address]
             self._points[point_id] = IrrigationPoint(point_conf, ads, self._logger)
+
+        # Start periodic measurements
+        self._start_measurement_timer()
 
     def _setup_ads_modules(self) -> None:
         """Deduplicate ADS addresses and initialize ADS modules."""
@@ -42,3 +47,27 @@ class IrrigationStation:
         if point_id not in self._points:
             raise ValueError(f"Irrigation point '{point_id}' not found.")
         return self._points[point_id]
+
+    def _start_measurement_timer(self) -> None:
+        """Start the periodic measurement timer."""
+        # Calculate interval to collect rolling_window samples over 5 minutes (300,000 ms)
+        interval_ms = 300_000 // self._config.rolling_window
+        self._measurement_timer.init(
+            period=interval_ms,
+            mode=Timer.PERIODIC,
+            callback=self._set_pending_measurement,
+        )
+        self._logger.log(f"Periodic sensor measurement started (every {interval_ms} ms)")
+
+    def _set_pending_measurement(self, _=None) -> None:
+        self._pending_measurement = True
+
+    def handle_pending_measurement(self) -> None:
+        if self._pending_measurement:
+            self._measure_all_sensors()
+            self._pending_measurement = False
+
+    def _measure_all_sensors(self) -> None:
+        """Measure all sensors to update their rolling averages."""
+        for point in self._points.values():
+            point.measure_sensor()

--- a/src/irrigation_station.py
+++ b/src/irrigation_station.py
@@ -50,8 +50,8 @@ class IrrigationStation:
 
     def _start_measurement_timer(self) -> None:
         """Start the periodic measurement timer."""
-        # Calculate interval to collect rolling_window samples over 5 minutes (300,000 ms)
-        interval_ms = 300_000 // self._config.rolling_window
+        # Calculate interval to collect rolling_window samples over the publish interval
+        interval_ms = self._config.publish_interval_ms // self._config.rolling_window
         self._measurement_timer.init(
             period=interval_ms,
             mode=Timer.PERIODIC,

--- a/src/main.py
+++ b/src/main.py
@@ -44,6 +44,7 @@ def main() -> None:
             mqtt_manager.check_msg()
             time_keeper.handle_pending_ntp_sync()
             mqtt_manager.handle_pending_messages()
+            station.handle_pending_measurement()
             
             loop_count += 1
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 from machine import reset, Pin
-from time import sleep, ticks_ms
+from time import sleep
 from mqtt_hass_manager import MqttHassManager
 from irrigation_station import IrrigationStation
 from logger import Logger

--- a/src/mqtt_hass_manager.py
+++ b/src/mqtt_hass_manager.py
@@ -12,7 +12,6 @@ CERT_PATH = "./irrigationbackyard_crt.der"
 KEY_PATH = "./irrigationbackyard_key.der"
 PORT = 8883
 KEEPALIVE = 60
-PUBLISH_INTERVAL = 300_000
 BROKER_CONNECTIVITY_TEST_INTERVAL = 1800000
 
 
@@ -180,7 +179,7 @@ class MqttHassManager:
 
     def _start_periodic_publish(self) -> None:
         self._timer.init(
-            period=PUBLISH_INTERVAL,
+            period=self._config.publish_interval_ms,
             mode=Timer.PERIODIC,
             callback=self._set_pending_publish,
         )

--- a/src/mqtt_hass_manager.py
+++ b/src/mqtt_hass_manager.py
@@ -5,10 +5,8 @@ from logger import Logger
 from irrigation_station import IrrigationStation
 from mqtt_hass_entities import MqttHassSensor, MqttHassValve, MessagerParams
 from ssl import SSLContext, PROTOCOL_TLS_CLIENT
-from time import sleep, ticks_ms
+from time import ticks_ms
 
-MAX_RETRY_TIME = 30
-RETRY_DELAY = 2
 CA_PATH = "./ca_crt.der"
 CERT_PATH = "./irrigationbackyard_crt.der"
 KEY_PATH = "./irrigationbackyard_key.der"

--- a/src/mqtt_hass_manager.py
+++ b/src/mqtt_hass_manager.py
@@ -14,7 +14,7 @@ CERT_PATH = "./irrigationbackyard_crt.der"
 KEY_PATH = "./irrigationbackyard_key.der"
 PORT = 8883
 KEEPALIVE = 60
-PUBLISH_INTERVAL = 240_000
+PUBLISH_INTERVAL = 300_000
 BROKER_CONNECTIVITY_TEST_INTERVAL = 1800000
 
 

--- a/src/mqtt_robust_client.py
+++ b/src/mqtt_robust_client.py
@@ -8,7 +8,6 @@ class MqttRobustClient(MQTTClient):
     """MQTT Client based on umqtt.robust with threading-safe callback pattern"""
     
     DELAY = 2
-    DEBUG = False
     MAX_RECONNECT_FAILURES = 30
     MAX_MESSAGE_FAILURES = 10
 

--- a/src/rolling_average.py
+++ b/src/rolling_average.py
@@ -1,1 +1,51 @@
-# implement RollingAverage here
+from typing import List
+
+
+class RollingAverage:
+    """A class to compute rolling averages for smoothing sensor readings."""
+
+    def __init__(self, window_size: int = 5, alpha: float = 0.2) -> None:
+        """
+        Initialize the rolling average.
+
+        Args:
+            window_size: Number of readings to average for SMA. Ignored for EMA.
+            alpha: Smoothing factor for EMA (0 < alpha <= 1). Higher values give more weight to recent readings.
+        """
+        self._window_size = window_size
+        self._alpha = alpha
+        self._values: List[float] = []
+        self._ema_value: float = None  # type: ignore
+
+    def add_reading(self, value: float) -> None:
+        """Add a new reading to the rolling average."""
+        if self._ema_value is None:
+            # Initialize EMA with the first value
+            self._ema_value = value
+        else:
+            # Update EMA
+            self._ema_value = self._alpha * value + (1 - self._alpha) * self._ema_value
+
+        # Maintain SMA buffer
+        self._values.append(value)
+        if len(self._values) > self._window_size:
+            self._values.pop(0)
+
+    def get_average(self) -> float:
+        """Get the current averaged value. Returns EMA if available, otherwise SMA."""
+        if self._ema_value is not None:
+            return self._ema_value
+        elif self._values:
+            return sum(self._values) / len(self._values)
+        else:
+            return 0.0  # Default if no readings
+
+    def get_sma(self) -> float:
+        """Get the simple moving average."""
+        if not self._values:
+            return 0.0
+        return sum(self._values) / len(self._values)
+
+    def get_ema(self) -> float:
+        """Get the exponential moving average."""
+        return self._ema_value if self._ema_value is not None else 0.0

--- a/src/rolling_average.py
+++ b/src/rolling_average.py
@@ -1,0 +1,1 @@
+# implement RollingAverage here

--- a/src/rolling_average.py
+++ b/src/rolling_average.py
@@ -39,13 +39,3 @@ class RollingAverage:
             return sum(self._values) / len(self._values)
         else:
             return 0.0  # Default if no readings
-
-    def get_sma(self) -> float:
-        """Get the simple moving average."""
-        if not self._values:
-            return 0.0
-        return sum(self._values) / len(self._values)
-
-    def get_ema(self) -> float:
-        """Get the exponential moving average."""
-        return self._ema_value if self._ema_value is not None else 0.0

--- a/src/sensor.py
+++ b/src/sensor.py
@@ -24,7 +24,7 @@ class Sensor:
         )
 
         # Ensure sensor is powered off initially
-        self._mosfet.value(0)
+        self._mosfet.off()
 
     def measure(self) -> None:
         """Measure the sensor and update the rolling average without returning the value."""
@@ -60,7 +60,7 @@ class Sensor:
 
         finally:
             # Always power off the sensor
-            self._mosfet.value(0)
+            self._mosfet.off()
 
     def get_value(self) -> float:
         """Get the current averaged sensor value without measuring."""

--- a/src/sensor.py
+++ b/src/sensor.py
@@ -40,7 +40,8 @@ class Sensor:
             voltage = self._ads.raw_to_v(raw)
 
             # Normalize to 0.0-1.0 range (assuming 0-5V sensor range)
-            normalized_value = voltage / 5.0
+            # Round to 2 decimal places to handle minor floating-point variations
+            normalized_value = round(voltage / 5.0, 2)
 
             # Validate the computed value is in expected range
             if not (0.0 <= normalized_value <= 1.0):

--- a/src/valve.py
+++ b/src/valve.py
@@ -18,7 +18,7 @@ class Valve:
         self._logger = logger
 
         # Ensure valve is closed initially
-        self._valve.value(0)
+        self._valve.off()
 
     def open(self) -> None:
         """Open the irrigation valve."""

--- a/src/wifi_manager.py
+++ b/src/wifi_manager.py
@@ -17,7 +17,6 @@ class WiFiManager:
         self._wlan = WLAN(STA_IF)
         self._retry_time = 0
         self._timer = Timer(-1)
-        self._connected = False
         self._pending_connection_check = False
 
         country("nl")
@@ -48,10 +47,8 @@ class WiFiManager:
             sleep(RETRY_DELAY)
 
         if self._wlan.status() == 3:
-            self._connected = True
             self._log_connection_info()
         else:
-            self._connected = False
             self._logger.log("WiFi connection failed, going to reset")
             reset()
 


### PR DESCRIPTION
The readings from moisture sensors can fluctuate a bit and I want to stabilise this. To address the problem I want to use a rolling average:
- take readings periodically, for example 3 times per sensor publish duration (PUBLISH_INTERVAL in hass_mqtt_client)
- decouple the sensor readings from the publish logic. In the main loop we should call station.handle_pending_sensor_readings()
- The station should be responsible for the timing side of things but the measurement side of things should be implemented in the sensor class. So the station should periodically call a method on each sensor to update the value. 
- implement a RollingAverage class: a circular buffer with rolling average built-in. The size should be 10. This class should be in its own file
